### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Overview
 
 This manual is effective as of August 10, 2020*. The information in this site, along with all prior versions of this manual, is stored at [GitHub](https://github.com/Chicago/tnp-reporting-manual/releases).
 
-As part of its licensing process for Transportation Network Providers (sometimes called Ride-hail Providers), Chicago requires the companies to report on their activities monthly. These requirements are set forth in [Chapter 9-115](http://library.amlegal.com/nxt/gateway.dll/Illinois/chicago_il/title9vehiclestrafficandrailtransportati/chapter9-115transportationnetworkprovide?f=templates$fn=default.htm$3.0$vid=amlegal:chicago_il$anc=JD_Ch.9-115) of the Municipal Code of Chicago and [Rule TNP2.02](https://www.cityofchicago.org/content/dam/city/depts/bacp/rulesandregs/TNPRulesAmendedeffJan12017.pdf) issued by the Department of Business Affairs & Consumer Protection.
+As part of its licensing process for Transportation Network Providers (sometimes called Ride-hail Providers), Chicago requires the companies to report on their activities monthly. These requirements are set forth in [Chapter 9-115](http://library.amlegal.com/nxt/gateway.dll/Illinois/chicago_il/title9vehiclestrafficandrailtransportati/chapter9-115transportationnetworkprovide?f=templates$fn=default.htm$3.0$vid=amlegal:chicago_il$anc=JD_Ch.9-115) of the Municipal Code of Chicago and [Rule TNP2.02](https://www.chicago.gov/content/dam/city/depts/dol/rulesandregs/TNPRulesAmendedeff81020.pdf) issued by the Department of Business Affairs & Consumer Protection.
 
 For questions relating to these reporting requirements, please e-mail [tnp-data-reporting@cityofchicago.org](mailto:tnp-data-reporting@cityofchicago.org).
 


### PR DESCRIPTION
Changed the link to the BACP Rule TNP2.02 from the 2017 version to the 2020 version. Closes #27.